### PR TITLE
Fix build issue

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -9,7 +9,7 @@ LOCAL_PACKAGE_NAME := IchnaeaNlpBackend
 ichnaea_root  := $(LOCAL_PATH)
 ichnaea_out   := $(OUT_DIR)/target/common/obj/APPS/$(LOCAL_MODULE)_intermediates
 ichnaea_build := $(ichnaea_root)/build
-ichnaea_apk   := build/outputs/apk/IchnaeaNlpBackend-release-unsigned.apk
+ichnaea_apk   := build/outputs/apk/release/IchnaeaNlpBackend-release-unsigned.apk
 
 $(ichnaea_root)/$(ichnaea_apk):
 	rm -Rf $(ichnaea_build)


### PR DESCRIPTION
Building the module with LineageOS (I presume any other would be the same) fails because it can't find the APK file. This fix updates the path to the generated APK.